### PR TITLE
[Feat] 어드민-세미나 관리 컨트롤러 구현

### DIFF
--- a/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
+++ b/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
@@ -1,0 +1,96 @@
+package com.hongik.devtalk.controller.seminar;
+
+import com.hongik.devtalk.domain.seminar.admin.dto.ApplicantResponseDTO;
+import com.hongik.devtalk.domain.seminar.admin.dto.QuestionResponseDTO;
+import com.hongik.devtalk.domain.seminar.admin.dto.SeminarCardResponseDTO;
+import com.hongik.devtalk.domain.seminar.admin.dto.SeminarReviewResponseDTO;
+import com.hongik.devtalk.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "[Admin]Seminar", description = "어드민 - 세미나 관련 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/seminars")
+public class SeminarAdminController {
+
+    @Operation(summary = "세미나 카드리스트 조회", description = "세미나 카드리스트를 조회합니다.")
+    @GetMapping("/card")
+    public ApiResponse<List<SeminarCardResponseDTO>> getSeminarCards() {
+
+        return ApiResponse.onSuccess("세미나 카드 리스트 조회에 성공했습니다.");
+    }
+
+    @Operation(summary = "세미나 삭제", description = "해당 세미나를 영구적으로 삭제합니다.")
+    @DeleteMapping("/{seminarId}")
+    public ApiResponse<Void> deleteSeminar(
+            @Parameter(description = "삭제할 세미나 ID", required = true)
+            @PathVariable Long seminarId
+    ) {
+
+        return ApiResponse.onSuccess("세미나를 삭제했습니다.");
+    }
+
+    @Operation(summary = "세미나 후기 목록 조회", description = "세미나 상세 정보 조회 페이지 - 후기 목록 부분을 조회합니다.")
+    @GetMapping("/{seminarId}/reviews")
+    public ApiResponse<List<SeminarReviewResponseDTO>> getSeminarReviews(
+            @Parameter(description = "세미나 ID", required = true)
+            @PathVariable Long seminarId
+    ) {
+
+        return ApiResponse.onSuccess("세미나 후기 리스트 조회에 성공했습니다.");
+    }
+
+    @Operation(summary = "세미나 후기 홈 노출 ON", description = "세미나 후기를 홈 화면에 노출되게 설정합니다.")
+    @PostMapping("/reviews/{reviewId}/home/on")
+    public ApiResponse<Void> exposeReviewOnHome(
+            @Parameter(description = "후기 ID", required = true)
+            @PathVariable Long reviewId
+    ) {
+
+        return ApiResponse.onSuccess("후기를 홈 화면에 등록했습니다.");
+    }
+
+    @Operation(summary = "세미나 후기 홈 노출 OFF", description = "세미나 후기를 홈 화면에서 제외합니다.")
+    @PostMapping("/reviews/{reviewId}/home/off")
+    public ApiResponse<Void> removeReviewFromHome(
+            @Parameter(description = "후기 ID", required = true)
+            @PathVariable Long reviewId
+    ) {
+
+        return ApiResponse.onSuccess("후기를 홈 화면에서 제외했습니다.");
+    }
+
+    @Operation(summary = "세미나 후기 삭제", description = "세미나 후기를 영구적으로 삭제합니다.")
+    @DeleteMapping("/reviews/{reviewId}")
+    public ApiResponse<Void> deleteReview(
+            @Parameter(description = "후기 ID", required = true)
+            @PathVariable Long reviewId
+    ) {
+
+        return ApiResponse.onSuccess("세미나 후기를 삭제했습니다.");
+    }
+
+    @Operation(summary = "세미나 신청자 정보 조회", description = "세미나 신청자 정보를 조회합니다.")
+    @GetMapping("/{seminarId}/applicants")
+    public ApiResponse<List<ApplicantResponseDTO>> getApplicantsInfo(
+            @Parameter(description = "세미나 ID", required = true)
+            @PathVariable Long seminarId
+    ) {
+        return ApiResponse.onSuccess("세미나 신청자 조회에 성공했습니다.");
+    }
+
+    @Operation(summary = "세미나 연사별 질문 조회", description = "세미나 연사별 질문 정보를 조회합니다.")
+    @GetMapping("/{seminarId}/questions")
+    public ApiResponse<List<QuestionResponseDTO.QuestionListDTO>> getSpeakerQuestions(
+            @Parameter(description = "세미나 ID", required = true)
+            @PathVariable Long seminarId
+    ) {
+        return ApiResponse.onSuccess("세미나 연사별 질문 조회에 성공했습니다.");
+    }
+}

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/ApplicantResponseDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/ApplicantResponseDTO.java
@@ -1,0 +1,24 @@
+package com.hongik.devtalk.domain.seminar.admin.dto;
+
+import com.hongik.devtalk.domain.enums.InflowPath;
+import com.hongik.devtalk.domain.enums.ParticipationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApplicantResponseDTO {
+    private String topic;
+    private String studentId;
+    private String studentNum;
+    private String department;
+    private Integer grade;
+    private String name;
+    private String phone;
+    private ParticipationType participationType;
+    private InflowPath inflowPath;
+}

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/QuestionResponseDTO.java
@@ -1,0 +1,30 @@
+package com.hongik.devtalk.domain.seminar.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class QuestionResponseDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class QuestionDTO {
+        private Long questionId;
+        private String content;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class QuestionListDTO {
+        private Long speakerId;
+        private String speakerName;
+        private List<QuestionDTO> questions;
+    }
+}

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarCardResponseDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarCardResponseDTO.java
@@ -1,0 +1,25 @@
+package com.hongik.devtalk.domain.seminar.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SeminarCardResponseDTO {
+    private Long seminarId;
+    private Integer seminarNum;
+    private String thumbnail;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd (E) HH:mm", timezone = "Asia/Seoul")
+    private LocalDateTime seminarDate;
+
+    private String place;
+    private String topic;
+}

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarReviewResponseDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarReviewResponseDTO.java
@@ -1,0 +1,20 @@
+package com.hongik.devtalk.domain.seminar.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SeminarReviewResponseDTO {
+    private Long reviewId;
+    private Integer score;
+    private String department;
+    private Integer grade;
+    private String content;
+    private String nextTopic;
+    private Boolean isPublic;
+}


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
어드민 페이지 - 세미나 관리 관련 컨트롤러 스켈레톤 코드입니다.
- 세미나 카드리스트 조회
- 세미나 삭제
- 세미나 후기 목록 조회
- 세미나 후기 홈 노출 on/off
- 세미나 후기 삭제
- 세미나 신청자 목록 조회
- 세미나 연사별 질문 조회

세미나 상세정보 등록/수정/조회 관련 API는 아직 와이어프레임 수정 중인 부분이 있어서 와이어프레임이 확정되면 정리해서 올리겠습니다!

## 📸 작업 화면 스크린샷
<img width="1096" height="389" alt="image" src="https://github.com/user-attachments/assets/2b7b9bfc-409f-492a-a986-510103625593" />


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [#12]
