### PR TITLE
[Feat] 세미나, 세션 ERD 수정  

### DIFF
--- a/src/main/java/com/hongik/devtalk/domain/Seminar.java
+++ b/src/main/java/com/hongik/devtalk/domain/Seminar.java
@@ -1,5 +1,6 @@
 package com.hongik.devtalk.domain;
 
+import com.hongik.devtalk.domain.enums.SeminarStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,6 +21,9 @@ public class Seminar {
     @Column(name = "seminar_id")
     private Long id;
 
+    @Column(length = 2048)
+    private String thumbnailUrl;
+
     @Column(length = 50, nullable = false, unique = true)
     private int seminarNum; // 몇회차
 
@@ -35,6 +39,10 @@ public class Seminar {
     private LocalDateTime endDate;
 
     private String place;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SeminarStatus status;
 
     @OneToMany(mappedBy = "seminar", cascade = CascadeType.ALL)
     private List<Attendance> attendances = new ArrayList<>();

--- a/src/main/java/com/hongik/devtalk/domain/Session.java
+++ b/src/main/java/com/hongik/devtalk/domain/Session.java
@@ -1,7 +1,7 @@
 package com.hongik.devtalk.domain;
 
 import com.hongik.devtalk.domain.common.BaseTimeEntity;
-import com.hongik.devtalk.domain.enums.SessionStatus;
+import com.hongik.devtalk.domain.enums.SeminarStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -34,17 +34,6 @@ public class Session extends BaseTimeEntity {
 
     @Lob
     private String description;
-
-    @Column(nullable = false)
-    private LocalDateTime startAt;
-
-    @Column(nullable = false)
-    private LocalDateTime endAt;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private SessionStatus status;
-
 
     @OneToMany(mappedBy = "session", cascade = CascadeType.ALL)
     private List<SessionImage> seminarImages = new ArrayList<>();

--- a/src/main/java/com/hongik/devtalk/domain/enums/SeminarStatus.java
+++ b/src/main/java/com/hongik/devtalk/domain/enums/SeminarStatus.java
@@ -1,5 +1,5 @@
 package com.hongik.devtalk.domain.enums;
 
-public enum SessionStatus {
+public enum SeminarStatus {
     UPCOMING, LIVE, ENDED
 }


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
1. 세미나를 등록할때 썸네일 사진이 필요 -> Seminar 엔티티에 thumbnail_url 추가
    세미나 썸네일은 피그마상 최대 한장입니다!
2. 세션 기준이 아니라 세미나 기준으로 시작&끝이 관리됨 -> status enum('ENDED','LIVE','UPCOMING')을 Session 엔티티에서 Seminar 엔티티로 이동 (SeminarStatus로 이름 변경)
3. 세션의 시작 시간과 끝나는 시간 정보 불필요 -> Session 엔티티에 startAt, endAt 삭제


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
