### PR TITLE
[Feat] 로그아웃 구현, 유저 토큰, 어드민 토큰 권한 분리 확인

### DIFF
--- a/src/main/java/com/hongik/devtalk/controller/auth/AuthController.java
+++ b/src/main/java/com/hongik/devtalk/controller/auth/AuthController.java
@@ -61,11 +61,11 @@ public class AuthController {
     public ApiResponse<Void> logout(
             @Parameter(description = "인증 토큰", required = true)
             @RequestHeader(name = "Authorization", required = false) String authHeader,
-            @CookieValue(name = "refresh_token", required = false) String refreshCookie) {
+            @RequestBody LogoutRequestDto refreshTokenDTO) {
 
         //refreshToken 폐기
-        if (refreshCookie != null && !refreshCookie.isBlank()) {
-            adminCommandService.deleteRefreshToken(refreshCookie);
+        if (refreshTokenDTO.getRefreshToken() != null && !refreshTokenDTO.getRefreshToken().isBlank()) {
+            adminCommandService.deleteRefreshToken(refreshTokenDTO.getRefreshToken());
         }
 
         return ApiResponse.onSuccess("정상적으로 로그아웃되었습니다.");

--- a/src/main/java/com/hongik/devtalk/controller/auth/AuthController.java
+++ b/src/main/java/com/hongik/devtalk/controller/auth/AuthController.java
@@ -60,10 +60,14 @@ public class AuthController {
     })
     public ApiResponse<Void> logout(
             @Parameter(description = "인증 토큰", required = true)
-            @RequestHeader("Authorization") String authorization,
-            @RequestBody LogoutRequestDto logoutRequest
-    ) {
-        // TODO: 로그아웃 로직 구현
+            @RequestHeader(name = "Authorization", required = false) String authHeader,
+            @CookieValue(name = "refresh_token", required = false) String refreshCookie) {
+
+        //refreshToken 폐기
+        if (refreshCookie != null && !refreshCookie.isBlank()) {
+            adminCommandService.deleteRefreshToken(refreshCookie);
+        }
+
         return ApiResponse.onSuccess("정상적으로 로그아웃되었습니다.");
     }
 }

--- a/src/main/java/com/hongik/devtalk/domain/auth/dto/LogoutRequestDto.java
+++ b/src/main/java/com/hongik/devtalk/domain/auth/dto/LogoutRequestDto.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LogoutRequestDto {
     
-    private String userId;
+    private String refreshToken;
 }

--- a/src/main/java/com/hongik/devtalk/repository/auth/RefreshTokenRepository.java
+++ b/src/main/java/com/hongik/devtalk/repository/auth/RefreshTokenRepository.java
@@ -13,4 +13,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     RefreshToken findByAdminId(Long adminId);
 
     Optional<RefreshToken> findByToken(String token);
+
+    void deleteByToken(String token);
 }

--- a/src/main/java/com/hongik/devtalk/service/admin/AdminCommandService.java
+++ b/src/main/java/com/hongik/devtalk/service/admin/AdminCommandService.java
@@ -87,4 +87,9 @@ public class AdminCommandService {
 
         adminRepository.deleteById(adminId);
     }
+
+    public void deleteRefreshToken (String refreshToken) {
+
+        refreshTokenRepository.deleteByToken(refreshToken);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
-spring:
-  profiles:
-    active: dev # 본인이 테스트할 환경에 따라서 바꾸기
+#spring:
+  #profiles:
+    #active: dev # 본인이 테스트할 환경에 따라서 바꾸기

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
-#spring:
-#  profiles:
-    #active: dev # 본인이 테스트할 환경에 따라서 바꾸기
+spring:
+  profiles:
+    active: dev # 본인이 테스트할 환경에 따라서 바꾸기


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
로그아웃 구현이 예상보다 할게 없어서... PR 바로 올립니다
그리고 학생 로그인 권한은 ROLE_USER, 관리자 로그인은 ROLE_ADMIN으로 분리해놓은것 확인했고,
각자 API에 접근 못하는것도 테스트 확인 완료했습니다. (403)

리뷰어는
토큰 권한 확인 요청해주신 은서님이랑
학생 로그인 구현하신 신애님으로 하겠습니다.

## 📸 작업 화면 스크린샷
<img width="2888" height="1292" alt="스크린샷 2025-10-01 오후 10 37 42" src="https://github.com/user-attachments/assets/898ec1ae-d698-4259-aeeb-ad8bff4aec5c" />
<img width="2882" height="1292" alt="스크린샷 2025-10-01 오후 10 35 11" src="https://github.com/user-attachments/assets/c131c339-f151-4dc3-8d67-37c9f73d4352" />


## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [ ] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
