### PR TITLE
[Feat] 후기 카드 관리 기능 추가 (조회, 순위 변경, 삭제)

### DIFF
--- a/src/main/java/com/hongik/devtalk/controller/mainpage/MainpageController.java
+++ b/src/main/java/com/hongik/devtalk/controller/mainpage/MainpageController.java
@@ -5,6 +5,7 @@ import com.hongik.devtalk.domain.mainpage.dto.*;
 import com.hongik.devtalk.domain.enums.ImageType;
 import com.hongik.devtalk.service.mainpage.MainpageImagesService;
 import com.hongik.devtalk.service.mainpage.InquiryLinkService;
+import com.hongik.devtalk.service.mainpage.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,6 +30,7 @@ public class MainpageController {
 
     private final MainpageImagesService mainpageImagesService;
     private final InquiryLinkService inquiryLinkService;
+    private final ReviewService reviewService;
 
     // Images APIs
     @GetMapping("/images")
@@ -234,7 +236,8 @@ public class MainpageController {
     @GetMapping("/reviews")
     @Operation(
             summary = "후기 카드 전체 조회",
-            description = "후기 카드 전체 조회 (순위/표시 여부 포함)"
+            description = "후기 카드 전체 조회 (순위/표시 여부 포함)",
+            security = { @SecurityRequirement(name = "bearer-key") }
     )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -249,17 +252,17 @@ public class MainpageController {
             )
     })
     public ApiResponse<List<ReviewResponseDto>> getReviews(
-//            @Parameter(description = "인증 토큰", required = true)
-//            @RequestHeader("Authorization") String authorization
+            @AuthenticationPrincipal User user
     ) {
-        // TODO: 후기 카드 전체 조회 로직 구현
-        return ApiResponse.onSuccess("후기 카드를 조회했습니다.", null);
+        List<ReviewResponseDto> result = reviewService.getAllReviews();
+        return ApiResponse.onSuccess("후기 카드를 조회했습니다.", result);
     }
 
     @PutMapping("/reviews/order")
     @Operation(
             summary = "후기 카드 순위 일괄 변경",
-            description = "후기 카드 순위 일괄 변경"
+            description = "후기 카드 순위 일괄 변경",
+            security = { @SecurityRequirement(name = "bearer-key") }
     )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -279,18 +282,18 @@ public class MainpageController {
             )
     })
     public ApiResponse<ReorderResponseDto> reorderReviews(
-//            @Parameter(description = "인증 토큰", required = true)
-//            @RequestHeader("Authorization") String authorization,
+            @AuthenticationPrincipal User user,
             @Valid @RequestBody ReorderRequestDto request
     ) {
-        // TODO: 후기 카드 순위 변경 로직 구현
-        return ApiResponse.onSuccess("후기 카드 순서를 갱신했습니다.", null);
+        ReorderResponseDto result = reviewService.reorderReviews(request.getOrderedIds());
+        return ApiResponse.onSuccess("후기 카드 순서를 갱신했습니다.", result);
     }
 
     @DeleteMapping("/reviews/{reviewId}")
     @Operation(
             summary = "후기 카드 삭제",
-            description = "후기 카드 삭제"
+            description = "후기 카드 삭제",
+            security = { @SecurityRequirement(name = "bearer-key") }
     )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -310,12 +313,11 @@ public class MainpageController {
             )
     })
     public ApiResponse<DeleteReviewResponseDto> deleteReview(
-//            @Parameter(description = "인증 토큰", required = true)
-//            @RequestHeader("Authorization") String authorization,
+            @AuthenticationPrincipal User user,
             @Parameter(description = "후기 ID", required = true)
             @PathVariable("reviewId") String reviewId
     ) {
-        // TODO: 후기 카드 삭제 로직 구현
-        return ApiResponse.onSuccess("후기 카드를 삭제했습니다.", null);
+        DeleteReviewResponseDto result = reviewService.deleteReview(reviewId);
+        return ApiResponse.onSuccess("후기 카드를 삭제했습니다.", result);
     }
 }

--- a/src/main/java/com/hongik/devtalk/domain/Review.java
+++ b/src/main/java/com/hongik/devtalk/domain/Review.java
@@ -52,8 +52,17 @@ public class Review extends BaseTimeEntity {
     @ColumnDefault("false")
     private boolean isNote;
 
+    // 홈화면 노출 순서 (낮을수록 상단, null이면 노출 안됨)
+    @Column
+    private Integer displayOrder;
+
     // 홈화면 노출 여부 업데이트
     public void updateIsNote(boolean isNote) {
         this.isNote = isNote;
+    }
+
+    // 홈화면 노출 순서 업데이트
+    public void updateDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
     }
 }

--- a/src/main/java/com/hongik/devtalk/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/hongik/devtalk/global/apiPayload/code/GeneralErrorCode.java
@@ -27,6 +27,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
 
     // 후기 에러
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_4041", "존재하지 않는 후기입니다."),
+    INCOMPLETE_REVIEW_ORDER(HttpStatus.BAD_REQUEST, "REVIEW_4002", "화면에 표시되어야 하는 후기 중 누락된 업데이트가 존재합니다."),
 
     // 요청/파라미터 에러
     MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "REQ_4001", "필수 파라미터가 누락되었습니다."),

--- a/src/main/java/com/hongik/devtalk/repository/review/ReviewRepository.java
+++ b/src/main/java/com/hongik/devtalk/repository/review/ReviewRepository.java
@@ -2,6 +2,16 @@ package com.hongik.devtalk.repository.review;
 
 import com.hongik.devtalk.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    
+    // 모든 후기 조회 (displayOrder 오름차순, null은 마지막)
+    @Query("SELECT r FROM Review r ORDER BY CASE WHEN r.displayOrder IS NULL THEN 1 ELSE 0 END, r.displayOrder ASC, r.createdAt DESC")
+    List<Review> findAllOrderByDisplayOrder();
+    
+    // 홈 화면에 표시되는 후기 조회 (isNote = true)
+    List<Review> findByIsNoteTrue();
 }

--- a/src/main/java/com/hongik/devtalk/service/mainpage/ReviewService.java
+++ b/src/main/java/com/hongik/devtalk/service/mainpage/ReviewService.java
@@ -1,0 +1,154 @@
+package com.hongik.devtalk.service.mainpage;
+
+import com.hongik.devtalk.domain.Review;
+import com.hongik.devtalk.domain.mainpage.dto.DeleteReviewResponseDto;
+import com.hongik.devtalk.domain.mainpage.dto.ReorderResponseDto;
+import com.hongik.devtalk.domain.mainpage.dto.ReviewResponseDto;
+import com.hongik.devtalk.global.apiPayload.code.GeneralErrorCode;
+import com.hongik.devtalk.global.apiPayload.exception.GeneralException;
+import com.hongik.devtalk.repository.review.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    /**
+     * 후기 카드 전체 조회 (순위/표시 여부 포함)
+     */
+    public List<ReviewResponseDto> getAllReviews() {
+        List<Review> reviews = reviewRepository.findAllOrderByDisplayOrder();
+        
+        return reviews.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 후기 카드 순위 일괄 변경
+     * @param orderedIds 원하는 최종 순서의 reviewId 배열(첫 번째가 1위)
+     */
+    @Transactional
+    public ReorderResponseDto reorderReviews(List<String> orderedIds) {
+        if (orderedIds == null || orderedIds.isEmpty()) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER);
+        }
+
+        // 1. 홈 화면에 표시되어야 하는 모든 후기 조회 (isNote = true)
+        List<Review> displayedReviews = reviewRepository.findByIsNoteTrue();
+        
+        // 2. 요청된 ID 개수와 실제 표시되어야 하는 후기 개수 비교
+        if (orderedIds.size() != displayedReviews.size()) {
+            log.error("표시되어야 하는 후기 개수({})와 요청된 ID 개수({})가 일치하지 않습니다.", 
+                     displayedReviews.size(), orderedIds.size());
+            throw new GeneralException(GeneralErrorCode.INCOMPLETE_REVIEW_ORDER);
+        }
+        
+        // 3. 표시되어야 하는 후기의 ID 집합 생성
+        Set<Long> displayedReviewIds = displayedReviews.stream()
+                .map(Review::getId)
+                .collect(Collectors.toSet());
+        
+        // 4. 요청된 ID들을 Long으로 변환하고 검증
+        Set<Long> requestedReviewIds = new HashSet<>();
+        for (String reviewIdStr : orderedIds) {
+            Long reviewId;
+            try {
+                reviewId = Long.parseLong(reviewIdStr);
+            } catch (NumberFormatException e) {
+                log.error("잘못된 reviewId 형식: {}", reviewIdStr);
+                throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER);
+            }
+            requestedReviewIds.add(reviewId);
+        }
+        
+        // 5. 두 집합이 동일한지 확인 (누락되거나 추가된 ID가 없는지)
+        if (!displayedReviewIds.equals(requestedReviewIds)) {
+            log.error("표시되어야 하는 후기 ID와 요청된 ID가 일치하지 않습니다. " +
+                     "표시되어야 하는 ID: {}, 요청된 ID: {}", 
+                     displayedReviewIds, requestedReviewIds);
+            throw new GeneralException(GeneralErrorCode.INCOMPLETE_REVIEW_ORDER);
+        }
+
+        int updatedCount = 0;
+
+        // 6. 각 reviewId에 대해 순서 업데이트
+        for (int i = 0; i < orderedIds.size(); i++) {
+            Long reviewId = Long.parseLong(orderedIds.get(i));
+            
+            Review review = reviewRepository.findById(reviewId)
+                    .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
+
+            // isNote가 true인지 재확인 (이중 검증)
+            if (!review.isNote()) {
+                log.error("홈 화면에 표시되지 않는 후기가 포함되었습니다. reviewId: {}", reviewId);
+                throw new GeneralException(GeneralErrorCode.INCOMPLETE_REVIEW_ORDER);
+            }
+
+            // displayOrder를 1부터 시작하도록 설정 (i+1)
+            review.updateDisplayOrder(i + 1);
+            updatedCount++;
+        }
+
+        log.info("후기 순서 변경 완료: {} 건", updatedCount);
+
+        return ReorderResponseDto.builder()
+                .updatedCount(updatedCount)
+                .build();
+    }
+
+    /**
+     * 후기 카드 삭제
+     * @param reviewId 후기 ID
+     */
+    @Transactional
+    public DeleteReviewResponseDto deleteReview(String reviewId) {
+        Long id;
+        
+        try {
+            id = Long.parseLong(reviewId);
+        } catch (NumberFormatException e) {
+            log.error("잘못된 reviewId 형식: {}", reviewId);
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER);
+        }
+
+        Review review = reviewRepository.findById(id)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
+
+        reviewRepository.delete(review);
+        
+        log.info("후기 삭제 완료: reviewId={}", reviewId);
+
+        return DeleteReviewResponseDto.builder()
+                .reviewId(reviewId)
+                .build();
+    }
+
+    /**
+     * Review 엔티티를 DTO로 변환
+     */
+    private ReviewResponseDto convertToDto(Review review) {
+        return ReviewResponseDto.builder()
+                .reviewId(String.valueOf(review.getId()))
+                .rating(Integer.valueOf(review.getScore()))
+                .title(null) // 엔티티에 없는 필드
+                .content(review.getStrength())
+                .order(review.getDisplayOrder())
+                .visible(review.isNote())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}
+


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
### 1) Review 엔티티 확장
- `displayOrder` 필드 추가  
  - 값이 낮을수록 상단에 표시  
  - `null`이면 순서 미지정 상태

### 2) ReviewRepository 확장
- `findAllOrderByDisplayOrder()` : 모든 후기를 노출 순서대로 조회  
  - `displayOrder`가 있는 후기를 우선 반환
- `findByIsNoteTrue()` : 홈 화면에 표시되는 후기만 조회

### 3) ReviewService 생성
- `getAllReviews` : 후기 전체 조회  
  - 모든 후기를 `displayOrder` 기준으로 정렬하여 반환
- `reorderReviews` : 후기 순서 일괄 변경  
  - 관리자가 지정한 순서대로 각 후기의 `displayOrder` 업데이트  
  - 검증 실패 시 에러 코드 `INCOMPLETE_REVIEW_ORDER` 반환  
    - 메시지: "화면에 표시되어야 하는 후기 중 누락된 업데이트가 존재합니다."
- `deleteReview` : 후기 삭제  
  - `reviewId`로 특정 후기를 영구 삭제

## 📸 작업 화면 스크린샷
<img width="1822" height="1113" alt="스크린샷 2025-10-02 오후 9 09 37" src="https://github.com/user-attachments/assets/ce2be5e4-5636-489d-9fc0-f5ff46f3089b" />
<img width="1822" height="1113" alt="스크린샷 2025-10-02 오후 9 14 09" src="https://github.com/user-attachments/assets/5cdfb5d6-44dd-432c-bf29-1e1fe89cd4f8" />
<img width="1822" height="1113" alt="스크린샷 2025-10-02 오후 9 33 47" src="https://github.com/user-attachments/assets/99a9ea4f-f905-47a4-9482-55a38a9e284c" />
<img width="1822" height="1113" alt="스크린샷 2025-10-02 오후 9 34 58" src="https://github.com/user-attachments/assets/856eca28-3965-417f-830d-9550a52ee2d6" />

## ⚠️ PR하기 전에 확인해주세요

- [ ] 로컬테스트를 진행하셨나요?
- [ ] 머지할 브랜치를 확인하셨나요?
- [ ] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
