### PR TITLE
[Feat] 세미나 등록, 수정, 삭제 API 개발

### DIFF
--- a/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
+++ b/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
@@ -44,6 +44,18 @@ public class SeminarAdminController {
         return ApiResponse.onSuccess("세미나 등록에 성공했습니다.", result);
     }
 
+    @Operation(summary = "세미나 정보 수정", description = "세미나 기본 정보, 연사 정보, 라이브 링크 등을 수정합니다. " +
+            "PUT 메서드로, 수정하지 않는 필드까지 모두 보내주셔야 합니다. 라이브 링크를 삭제하는 경우에는 null로 보내주세요.")
+    @PutMapping("/{seminarId}")
+    public ApiResponse<SeminarInfoResponseDTO> updateSeminar(
+            @Parameter(description = "세미나 ID", required = true)
+            @PathVariable Long seminarId,
+            @Valid @RequestBody SeminarUpdateRequestDTO request
+    ) {
+        SeminarInfoResponseDTO response = seminarAdminCommandService.updateSeminar(seminarId, request);
+        return ApiResponse.onSuccess("세미나 정보 수정에 성공했습니다.", response);
+    }
+
     @Operation(summary = "세미나 삭제", description = "해당 세미나를 영구적으로 삭제합니다.")
     @DeleteMapping("/{seminarId}")
     public ApiResponse<Void> deleteSeminar(

--- a/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
+++ b/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
@@ -1,17 +1,17 @@
 package com.hongik.devtalk.controller.seminar;
 
-import com.hongik.devtalk.domain.seminar.admin.dto.ApplicantResponseDTO;
-import com.hongik.devtalk.domain.seminar.admin.dto.QuestionResponseDTO;
-import com.hongik.devtalk.domain.seminar.admin.dto.SeminarCardResponseDTO;
-import com.hongik.devtalk.domain.seminar.admin.dto.SeminarReviewResponseDTO;
+import com.hongik.devtalk.domain.seminar.admin.dto.*;
 import com.hongik.devtalk.global.apiPayload.ApiResponse;
 import com.hongik.devtalk.service.seminar.SeminarAdminCommandService;
 import com.hongik.devtalk.service.seminar.SeminarAdminQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -29,6 +29,19 @@ public class SeminarAdminController {
     public ApiResponse<List<SeminarCardResponseDTO>> getSeminarCards() {
 
         return ApiResponse.onSuccess("세미나 카드 리스트 조회에 성공했습니다.");
+    }
+
+    @Operation(summary = "세미나 등록", description = "세미나 기본 정보와 파일을 함께 등록합니다.")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<SeminarInfoResponseDTO> registerSeminar(
+            @Valid @RequestPart("seminarRequest") SeminarRegisterRequestDTO request,
+            @RequestPart("thumbnailFile") MultipartFile thumbnailFile,
+            @RequestPart(value = "materials", required = false) List<MultipartFile> materials,
+            @RequestPart("speakerProfiles") List<MultipartFile> speakerProfiles
+    ) {
+        SeminarInfoResponseDTO result =
+                seminarAdminCommandService.registerSeminar(request, thumbnailFile, materials, speakerProfiles);
+        return ApiResponse.onSuccess("세미나 등록에 성공했습니다.", result);
     }
 
     @Operation(summary = "세미나 삭제", description = "해당 세미나를 영구적으로 삭제합니다.")

--- a/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
+++ b/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
@@ -34,9 +34,16 @@ public class SeminarAdminController {
     @Operation(summary = "세미나 등록", description = "세미나 기본 정보와 파일을 함께 등록합니다.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<SeminarInfoResponseDTO> registerSeminar(
+            @Parameter(description = "세미나 등록 요청 DTO (회차, 주제, 장소, 일정, 연사 정보 등 기본 정보)")
             @Valid @RequestPart("seminarRequest") SeminarRegisterRequestDTO request,
+
+            @Parameter(description = "세미나 대표 썸네일 이미지 파일 (필수)")
             @RequestPart("thumbnailFile") MultipartFile thumbnailFile,
+
+            @Parameter(description = "세미나 자료 파일 리스트 (선택)")
             @RequestPart(value = "materials", required = false) List<MultipartFile> materials,
+
+            @Parameter(description = "연사 프로필 이미지 파일 리스트 (연사 수와 동일 개수 필수)")
             @RequestPart("speakerProfiles") List<MultipartFile> speakerProfiles
     ) {
         SeminarInfoResponseDTO result =
@@ -54,6 +61,33 @@ public class SeminarAdminController {
     ) {
         SeminarInfoResponseDTO response = seminarAdminCommandService.updateSeminar(seminarId, request);
         return ApiResponse.onSuccess("세미나 정보 수정에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "세미나 파일 수정", description = "세미나 썸네일, 자료 파일 추가/삭제, 연사 프로필을 수정합니다.")
+    @PatchMapping(value = "/{seminarId}/files", consumes = {"multipart/form-data"})
+    public ApiResponse<SeminarInfoResponseDTO> updateSeminarFiles(
+            @Parameter(description = "세미나 ID", required = true)
+            @PathVariable Long seminarId,
+
+            @Parameter(description = "새로 교체할 세미나 대표 썸네일 이미지 (있으면 기존 썸네일 교체)")
+            @RequestPart(value = "thumbnailFile", required = false) MultipartFile thumbnailFile,
+
+            @Parameter(description = "추가할 세미나 자료 파일 리스트")
+            @RequestPart(value = "materials", required = false) List<MultipartFile> materials,
+
+            @Parameter(description = "삭제할 세미나 자료 파일 URL 리스트")
+            @RequestParam(value = "deleteMaterialUrls", required = false) List<String> deleteMaterialUrls,
+
+            @Parameter(description = "프로필 이미지를 교체할 연사 ID 리스트 (speakerProfiles와 인덱스 매칭)")
+            @RequestParam(value = "speakerIds", required = false) List<Long> speakerIds,
+
+            @Parameter(description = "새로 교체할 연사 프로필 이미지 파일 리스트 (speakerIds와 인덱스 매칭)")
+            @RequestPart(value = "speakerProfiles", required = false) List<MultipartFile> speakerProfiles
+    ) {
+        SeminarInfoResponseDTO result = seminarAdminCommandService.updateSeminarFiles(
+                seminarId, thumbnailFile, materials, deleteMaterialUrls, speakerIds, speakerProfiles
+        );
+        return ApiResponse.onSuccess("세미나 파일 수정에 성공했습니다.", result);
     }
 
     @Operation(summary = "세미나 삭제", description = "해당 세미나를 영구적으로 삭제합니다.")

--- a/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
+++ b/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
@@ -4,6 +4,7 @@ import com.hongik.devtalk.domain.seminar.admin.dto.*;
 import com.hongik.devtalk.global.apiPayload.ApiResponse;
 import com.hongik.devtalk.service.seminar.SeminarAdminCommandService;
 import com.hongik.devtalk.service.seminar.SeminarAdminQueryService;
+import com.hongik.devtalk.service.seminar.SeminarReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,6 +24,7 @@ public class SeminarAdminController {
 
     private final SeminarAdminQueryService seminarAdminQueryService;
     private final SeminarAdminCommandService seminarAdminCommandService;
+    private final SeminarReviewService seminarReviewService;
 
     @Operation(summary = "세미나 카드리스트 조회", description = "세미나 카드리스트를 조회합니다.")
     @GetMapping("/card")
@@ -116,7 +118,7 @@ public class SeminarAdminController {
             @Parameter(description = "후기 ID", required = true)
             @PathVariable Long reviewId
     ) {
-        seminarAdminCommandService.exposeReviewToHome(reviewId);
+        seminarReviewService.exposeReviewToHome(reviewId);
         return ApiResponse.onSuccess("후기를 홈 화면에 등록했습니다.");
     }
 
@@ -126,7 +128,7 @@ public class SeminarAdminController {
             @Parameter(description = "후기 ID", required = true)
             @PathVariable Long reviewId
     ) {
-        seminarAdminCommandService.hideReviewFromHome(reviewId);
+        seminarReviewService.hideReviewFromHome(reviewId);
         return ApiResponse.onSuccess("후기를 홈 화면에서 제외했습니다.");
     }
 
@@ -136,7 +138,7 @@ public class SeminarAdminController {
             @Parameter(description = "후기 ID", required = true)
             @PathVariable Long reviewId
     ) {
-        seminarAdminCommandService.deleteReview(reviewId);
+        seminarReviewService.deleteReview(reviewId);
         return ApiResponse.onSuccess("세미나 후기를 삭제했습니다.");
     }
 

--- a/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
+++ b/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
@@ -98,7 +98,7 @@ public class SeminarAdminController {
             @Parameter(description = "삭제할 세미나 ID", required = true)
             @PathVariable Long seminarId
     ) {
-
+        seminarAdminCommandService.deleteSeminar(seminarId);
         return ApiResponse.onSuccess("세미나를 삭제했습니다.");
     }
 

--- a/src/main/java/com/hongik/devtalk/domain/Live.java
+++ b/src/main/java/com/hongik/devtalk/domain/Live.java
@@ -22,4 +22,8 @@ public class Live {
 
     @Column(length = 2048, nullable = false)
     private String liveUrl;
+
+    public void updateUrl(String url) {
+        this.liveUrl = url;
+    }
 }

--- a/src/main/java/com/hongik/devtalk/domain/LiveFile.java
+++ b/src/main/java/com/hongik/devtalk/domain/LiveFile.java
@@ -32,7 +32,9 @@ public class LiveFile {
     private String fileUrl;
 
     @Column(length = 50)
-    private String fileType;
+    private String fileExtension;
+
+    private Long fileSize;
 
     @CreatedDate
     @Column(nullable = false)

--- a/src/main/java/com/hongik/devtalk/domain/Seminar.java
+++ b/src/main/java/com/hongik/devtalk/domain/Seminar.java
@@ -4,7 +4,6 @@ import com.hongik.devtalk.domain.enums.SeminarStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +23,14 @@ public class Seminar {
     @Column(length = 2048)
     private String thumbnailUrl;
 
+    @Column(length = 255)
+    private String thumbnailFileName;
+
+    @Column(length = 20)
+    private String thumbnailFileExtension;
+
+    private Long thumbnailFileSize;
+
     @Column(length = 50, nullable = false, unique = true)
     private int seminarNum; // 몇회차
 
@@ -31,6 +38,12 @@ public class Seminar {
 
     //세미나가 진행되는 시간
     private LocalDateTime seminarDate;
+
+    // 세미나 활성화 시작 시간
+    private LocalDateTime activeStartDate;
+
+    // 세미나 활성화 종료 시간
+    private LocalDateTime activeEndDate;
 
     //신청 시작 시간
     private LocalDateTime startDate;

--- a/src/main/java/com/hongik/devtalk/domain/Seminar.java
+++ b/src/main/java/com/hongik/devtalk/domain/Seminar.java
@@ -54,7 +54,6 @@ public class Seminar {
     private String place;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private SeminarStatus status;
 
     @OneToMany(mappedBy = "seminar", cascade = CascadeType.ALL)

--- a/src/main/java/com/hongik/devtalk/domain/Seminar.java
+++ b/src/main/java/com/hongik/devtalk/domain/Seminar.java
@@ -63,7 +63,7 @@ public class Seminar {
     @OneToMany(mappedBy = "seminar", cascade = CascadeType.ALL)
     private List<Review> reviews = new ArrayList<>();
 
-    @OneToOne(mappedBy = "seminar", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "seminar", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Live live;
 
     @OneToMany(mappedBy = "seminar", cascade = CascadeType.ALL)
@@ -77,4 +77,21 @@ public class Seminar {
 
     @OneToMany(mappedBy = "seminar", cascade = CascadeType.ALL)
     private List<Remind> reminds = new ArrayList<>();
+
+    public void updateInfo(Integer seminarNum, LocalDateTime seminarDate, String place, String topic,
+                           LocalDateTime activeStartDate, LocalDateTime activeEndDate,
+                           LocalDateTime applyStartDate, LocalDateTime applyEndDate) {
+        this.seminarNum = seminarNum;
+        this.seminarDate = seminarDate;
+        this.place = place;
+        this.topic = topic;
+        this.activeStartDate = activeStartDate;
+        this.activeEndDate = activeEndDate;
+        this.startDate = applyStartDate;
+        this.endDate = applyEndDate;
+    }
+
+    public void updateLive(Live live) {
+        this.live = live;
+    }
 }

--- a/src/main/java/com/hongik/devtalk/domain/Seminar.java
+++ b/src/main/java/com/hongik/devtalk/domain/Seminar.java
@@ -94,4 +94,11 @@ public class Seminar {
     public void updateLive(Live live) {
         this.live = live;
     }
+
+    public void updateThumbnail(String url, String name, String ext, Long size) {
+        this.thumbnailUrl = url;
+        this.thumbnailFileName = name;
+        this.thumbnailFileExtension = ext;
+        this.thumbnailFileSize = size;
+    }
 }

--- a/src/main/java/com/hongik/devtalk/domain/Session.java
+++ b/src/main/java/com/hongik/devtalk/domain/Session.java
@@ -40,4 +40,9 @@ public class Session extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "session", cascade = CascadeType.ALL)
     private List<Question> questions = new ArrayList<>();
+
+    public void updateInfo(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
 }

--- a/src/main/java/com/hongik/devtalk/domain/Speaker.java
+++ b/src/main/java/com/hongik/devtalk/domain/Speaker.java
@@ -51,4 +51,10 @@ public class Speaker {
 
     @OneToMany(mappedBy = "speaker", cascade = CascadeType.ALL)
     private List<Session> sessions = new ArrayList<>();
+
+    public void updateInfo(String name, String organization, String history) {
+        this.name = name;
+        this.organization = organization;
+        this.history = history;
+    }
 }

--- a/src/main/java/com/hongik/devtalk/domain/Speaker.java
+++ b/src/main/java/com/hongik/devtalk/domain/Speaker.java
@@ -57,4 +57,11 @@ public class Speaker {
         this.organization = organization;
         this.history = history;
     }
+
+    public void updateProfile(String url, String name, String ext, Long size) {
+        this.profileUrl = url;
+        this.profileFileName = name;
+        this.profileFileExtension = ext;
+        this.profileFileSize = size;
+    }
 }

--- a/src/main/java/com/hongik/devtalk/domain/Speaker.java
+++ b/src/main/java/com/hongik/devtalk/domain/Speaker.java
@@ -21,14 +21,24 @@ public class Speaker {
     @Column(length = 50, nullable = false)
     private String name;
 
+    // 소속
     @Column(length = 100)
     private String organization;
 
+    // 이력
     @Lob
     private String history;
 
     @Column(length = 2048)
     private String profileUrl;
+
+    @Column(length = 255)
+    private String profileFileName;
+
+    @Column(length = 20)
+    private String profileFileExtension;
+
+    private Long profileFileSize;
 
     @Column(unique = true)
     private String email;

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarInfoResponseDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarInfoResponseDTO.java
@@ -1,0 +1,55 @@
+package com.hongik.devtalk.domain.seminar.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SeminarInfoResponseDTO {
+    private Long seminarId;
+    private Integer seminarNum;
+    private String topic;
+    private LocalDateTime seminarDate;
+    private String place;
+    private LocalDateTime activeStartDate;
+    private LocalDateTime activeEndDate;
+    private LocalDateTime applyStartDate;
+    private LocalDateTime applyEndDate;
+    private String liveLink;
+
+    private FileInfo thumbnail;
+    private List<FileInfo> materials;
+    private List<SpeakerResponse> speakers;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class FileInfo {
+        private String fileName;
+        private String fileExtension;
+        private Long fileSize;
+        private String fileUrl;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SpeakerResponse {
+        private Long speakerId;
+        private String name;
+        private String organization;
+        private String history;
+        private String sessionTitle;
+        private String sessionContent;
+        private FileInfo profile;
+    }
+}

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarInfoResponseDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarInfoResponseDTO.java
@@ -1,5 +1,6 @@
 package com.hongik.devtalk.domain.seminar.admin.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.hongik.devtalk.domain.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,9 +21,17 @@ public class SeminarInfoResponseDTO {
     private String topic;
     private LocalDateTime seminarDate;
     private String place;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd (E) HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime activeStartDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd (E) HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime activeEndDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd (E) HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime applyStartDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd (E) HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime applyEndDate;
     private String liveLink;
 

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarInfoResponseDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarInfoResponseDTO.java
@@ -1,5 +1,6 @@
 package com.hongik.devtalk.domain.seminar.admin.dto;
 
+import com.hongik.devtalk.domain.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -37,6 +39,15 @@ public class SeminarInfoResponseDTO {
         private String fileExtension;
         private Long fileSize;
         private String fileUrl;
+
+        public static FileInfo from(String name, String ext, Long size, String url) {
+            return FileInfo.builder()
+                    .fileName(name)
+                    .fileExtension(ext)
+                    .fileSize(size)
+                    .fileUrl(url)
+                    .build();
+        }
     }
 
     @Getter
@@ -51,5 +62,54 @@ public class SeminarInfoResponseDTO {
         private String sessionTitle;
         private String sessionContent;
         private FileInfo profile;
+    }
+
+    // DTO 변환
+    public static SeminarInfoResponseDTO from(Seminar seminar, Live live,
+                                              List<LiveFile> materials,
+                                              List<Session> sessions) {
+        return SeminarInfoResponseDTO.builder()
+                .seminarId(seminar.getId())
+                .seminarNum(seminar.getSeminarNum())
+                .topic(seminar.getTopic())
+                .seminarDate(seminar.getSeminarDate())
+                .place(seminar.getPlace())
+                .activeStartDate(seminar.getActiveStartDate())
+                .activeEndDate(seminar.getActiveEndDate())
+                .applyStartDate(seminar.getStartDate())
+                .applyEndDate(seminar.getEndDate())
+                .liveLink(live != null ? live.getLiveUrl() : null)
+                .thumbnail(FileInfo.from(
+                        seminar.getThumbnailFileName(),
+                        seminar.getThumbnailFileExtension(),
+                        seminar.getThumbnailFileSize(),
+                        seminar.getThumbnailUrl()
+                ))
+                .materials(materials.stream()
+                        .map(m -> FileInfo.from(m.getFileName(), m.getFileExtension(), m.getFileSize(), m.getFileUrl()))
+                        .collect(Collectors.toList()))
+                .speakers(sessions.stream()
+                        .map(SeminarInfoResponseDTO::toSpeakerResponse)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    // Speaker + Session → SpeakerResponse 변환
+    private static SpeakerResponse toSpeakerResponse(Session session) {
+        Speaker speaker = session.getSpeaker();
+        return SpeakerResponse.builder()
+                .speakerId(speaker.getId())
+                .name(speaker.getName())
+                .organization(speaker.getOrganization())
+                .history(speaker.getHistory())
+                .sessionTitle(session.getTitle())
+                .sessionContent(session.getDescription())
+                .profile(FileInfo.from(
+                        speaker.getProfileFileName(),
+                        speaker.getProfileFileExtension(),
+                        speaker.getProfileFileSize(),
+                        speaker.getProfileUrl()
+                ))
+                .build();
     }
 }

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarRegisterRequestDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarRegisterRequestDTO.java
@@ -1,0 +1,92 @@
+package com.hongik.devtalk.domain.seminar.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SeminarRegisterRequestDTO {
+
+    @NotNull
+    @Schema(description = "세미나 회차 번호", example = "1")
+    private Integer seminarNum;
+
+    @NotNull
+    @FutureOrPresent(message = "세미나 날짜는 현재 시각 이후여야 합니다.")
+    @Schema(description = "세미나 일시", example = "2025-12-10T10:00:00")
+    private LocalDateTime seminarDate;
+
+    @NotBlank
+    @Schema(description = "세미나 장소", example = "홍익대학교 R801호")
+    private String place;
+
+    @NotBlank
+    @Schema(description = "세미나 주제", example = "AI와 미래 사회")
+    private String topic;
+
+    @NotNull
+    @FutureOrPresent(message = "세미나 활성화 시작일은 현재 시각 이후여야 합니다.")
+    @Schema(description = "세미나 활성화 시작일", example = "2025-12-01T00:00:00")
+    private LocalDateTime activeStartDate;
+
+    @NotNull
+    @FutureOrPresent(message = "세미나 활성화 종료일은 현재 시각 이후여야 합니다.")
+    @Schema(description = "세미나 활성화 종료일", example = "2025-12-15T23:59:59")
+    private LocalDateTime activeEndDate;
+
+    @NotNull
+    @FutureOrPresent(message = "세미나 신청 시작일은 현재 시각 이후여야 합니다.")
+    @Schema(description = "세미나 신청 시작일", example = "2025-12-01T09:00:00")
+    private LocalDateTime applyStartDate;
+
+    @NotNull
+    @FutureOrPresent(message = "세미나 신청 종료일은 현재 시각 이후여야 합니다.")
+    @Schema(description = "세미나 신청 종료일", example = "2025-12-05T18:00:00")
+    private LocalDateTime applyEndDate;
+
+    @Schema(description = "세미나 온라인 링크(선택)", example = "https://youtube/j/123456789")
+    private String liveLink;
+
+    @Valid @NotNull
+    @Schema(description = "연사 정보 목록")
+    private List<SpeakerRegisterRequest> speakers;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SpeakerRegisterRequest {
+
+        @NotBlank
+        @Schema(description = "연사 이름", example = "홍길동")
+        private String name;
+
+        @NotBlank
+        @Schema(description = "연사 소속", example = "구글코리아")
+        private String organization;
+
+        @NotBlank
+        @Schema(description = "연사 이력", example = "전 네이버 AI 연구원, 현 구글코리아 시니어 엔지니어")
+        private String history;
+
+        @NotBlank
+        @Schema(description = "강연 제목", example = "AI 윤리와 책임 있는 기술")
+        private String sessionTitle;
+
+        @NotBlank
+        @Schema(description = "강연 내용", example = "이번 강연에서는 인공지능 기술의 윤리적 과제와 사회적 영향에 대해 이야기합니다.")
+        private String sessionContent;
+    }
+}

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarUpdateRequestDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarUpdateRequestDTO.java
@@ -1,0 +1,96 @@
+package com.hongik.devtalk.domain.seminar.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SeminarUpdateRequestDTO {
+
+    @NotNull
+    @Schema(description = "세미나 회차 번호", example = "1")
+    private Integer seminarNum;
+
+    @NotNull
+    @FutureOrPresent
+    @Schema(description = "세미나 일시", example = "2025-12-10T10:00:00")
+    private LocalDateTime seminarDate;
+
+    @NotBlank
+    @Schema(description = "세미나 장소", example = "홍익대학교 R801호")
+    private String place;
+
+    @NotBlank
+    @Schema(description = "세미나 주제", example = "AI와 미래 사회")
+    private String topic;
+
+    @NotNull
+    @FutureOrPresent
+    @Schema(description = "세미나 활성화 시작일", example = "2025-12-01T00:00:00")
+    private LocalDateTime activeStartDate;
+
+    @NotNull
+    @FutureOrPresent
+    @Schema(description = "세미나 활성화 종료일", example = "2025-12-15T23:59:59")
+    private LocalDateTime activeEndDate;
+
+    @NotNull
+    @FutureOrPresent
+    @Schema(description = "세미나 신청 시작일", example = "2025-12-01T09:00:00")
+    private LocalDateTime applyStartDate;
+
+    @NotNull
+    @FutureOrPresent
+    @Schema(description = "세미나 신청 종료일", example = "2025-12-05T18:00:00")
+    private LocalDateTime applyEndDate;
+
+    @Schema(description = "세미나 온라인 링크(삭제 시 null로)", example = "https://youtube.com/123456")
+    private String liveLink;
+
+    @Valid @NotNull
+    @Schema(description = "연사 정보 목록")
+    private List<SpeakerUpdateRequest> speakers;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SpeakerUpdateRequest {
+
+        @NotNull
+        @Schema(description = "연사 ID", example = "10")
+        private Long speakerId;
+
+        @NotBlank
+        @Schema(description = "연사 이름", example = "홍길동")
+        private String name;
+
+        @NotBlank
+        @Schema(description = "연사 소속", example = "구글코리아")
+        private String organization;
+
+        @NotBlank
+        @Schema(description = "연사 이력", example = "전 네이버 AI 연구원, 현 구글코리아 시니어 엔지니어")
+        private String history;
+
+        @NotBlank
+        @Schema(description = "강연 제목", example = "AI 윤리와 책임 있는 기술")
+        private String sessionTitle;
+
+        @NotBlank
+        @Schema(description = "강연 내용", example = "이번 강연에서는 인공지능 기술의 윤리적 과제와 사회적 영향에 대해 이야기합니다.")
+        private String sessionContent;
+    }
+}

--- a/src/main/java/com/hongik/devtalk/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/hongik/devtalk/global/apiPayload/code/GeneralErrorCode.java
@@ -21,6 +21,13 @@ public enum GeneralErrorCode implements BaseErrorCode {
     INVALID_SEMINAR_PERIOD(HttpStatus.BAD_REQUEST, "SEMINAR_4001", "세미나 신청 기간이 활성화 기간을 벗어났습니다."),
     INVALID_SPEAKER_PROFILE_COUNT(HttpStatus.BAD_REQUEST, "SEMINAR_4002", "연사 정보 수와 프로필 파일 수가 일치하지 않습니다."),
     INVALID_PERIOD_ORDER(HttpStatus.BAD_REQUEST, "SEMINAR_4003", "시작일은 종료일보다 이전이어야 합니다."),
+    SEMINAR_NUM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "SEMINAR_4004", "이미 존재하는 회차입니다."),
+
+    // 세션 에러
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_4041", "해당 세션을 찾을 수 없습니다."),
+
+    // 연사 에러
+    SPEAKER_NOT_FOUND(HttpStatus.NOT_FOUND, "SPEAKER_4041", "해당 연사를 찾을 수 없습니다."),
 
     // 이미지 에러
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_4041", "해당 타입의 이미지를 찾을 수 없습니다."),

--- a/src/main/java/com/hongik/devtalk/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/hongik/devtalk/global/apiPayload/code/GeneralErrorCode.java
@@ -16,9 +16,12 @@ public enum GeneralErrorCode implements BaseErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_4031", "접근 권한이 없습니다."),
     TOKEN_EXPIRED(HttpStatus.valueOf(419), "AUTH_4191", "토큰이 만료되었습니다."),
 
-    // 유저 에러
+    // 세미나 에러
     SEMINARINFO_NOT_FOUND(HttpStatus.NOT_FOUND,"SEMINARINFO_4041","seminarId를 찾을 수 없습니다."),
-    
+    INVALID_SEMINAR_PERIOD(HttpStatus.BAD_REQUEST, "SEMINAR_4001", "세미나 신청 기간이 활성화 기간을 벗어났습니다."),
+    INVALID_SPEAKER_PROFILE_COUNT(HttpStatus.BAD_REQUEST, "SEMINAR_4002", "연사 정보 수와 프로필 파일 수가 일치하지 않습니다."),
+    INVALID_PERIOD_ORDER(HttpStatus.BAD_REQUEST, "SEMINAR_4003", "시작일은 종료일보다 이전이어야 합니다."),
+
     // 이미지 에러
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_4041", "해당 타입의 이미지를 찾을 수 없습니다."),
     

--- a/src/main/java/com/hongik/devtalk/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/hongik/devtalk/global/apiPayload/code/GeneralErrorCode.java
@@ -29,6 +29,9 @@ public enum GeneralErrorCode implements BaseErrorCode {
     // 연사 에러
     SPEAKER_NOT_FOUND(HttpStatus.NOT_FOUND, "SPEAKER_4041", "해당 연사를 찾을 수 없습니다."),
 
+    // 세미나 자료 에러
+    LIVE_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "LIVE_FILE_4041", "해당 세미나 자료를 찾을 수 없습니다."),
+
     // 이미지 에러
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_4041", "해당 타입의 이미지를 찾을 수 없습니다."),
     

--- a/src/main/java/com/hongik/devtalk/global/config/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/hongik/devtalk/global/config/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,32 @@
+package com.hongik.devtalk.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    /** "Content-Type: multipart/form-data" 헤더를 지원하는 HTTP 요청 변환기 */
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/hongik/devtalk/repository/SessionRepository.java
+++ b/src/main/java/com/hongik/devtalk/repository/SessionRepository.java
@@ -2,13 +2,15 @@ package com.hongik.devtalk.repository;
 
 import com.hongik.devtalk.domain.Seminar;
 import com.hongik.devtalk.domain.Session;
+import com.hongik.devtalk.domain.Speaker;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SessionRepository extends JpaRepository<Session, Long> {
     List<Session> findSessionsBySeminar(Seminar seminar);
-
+    Optional<Session> findBySeminarAndSpeaker(Seminar seminar, Speaker speaker);
 }

--- a/src/main/java/com/hongik/devtalk/repository/live/LiveRepository.java
+++ b/src/main/java/com/hongik/devtalk/repository/live/LiveRepository.java
@@ -1,0 +1,11 @@
+package com.hongik.devtalk.repository.live;
+
+import com.hongik.devtalk.domain.Live;
+import com.hongik.devtalk.domain.Seminar;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LiveRepository extends JpaRepository<Live, Long> {
+    Optional<Live> findBySeminar(Seminar seminar);
+}

--- a/src/main/java/com/hongik/devtalk/repository/liveFile/LiveFileRepository.java
+++ b/src/main/java/com/hongik/devtalk/repository/liveFile/LiveFileRepository.java
@@ -1,11 +1,13 @@
-package com.hongik.devtalk.repository.seminar;
+package com.hongik.devtalk.repository.liveFile;
 
 import com.hongik.devtalk.domain.LiveFile;
 import com.hongik.devtalk.domain.Seminar;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LiveFileRepository extends JpaRepository<LiveFile, Long> {
     List<LiveFile> findBySeminar(Seminar seminar);
+    Optional<LiveFile> findByFileUrl(String fileUrl);
 }

--- a/src/main/java/com/hongik/devtalk/repository/seminar/LiveFileRepository.java
+++ b/src/main/java/com/hongik/devtalk/repository/seminar/LiveFileRepository.java
@@ -1,0 +1,7 @@
+package com.hongik.devtalk.repository.seminar;
+
+import com.hongik.devtalk.domain.LiveFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LiveFileRepository extends JpaRepository<LiveFile, Long> {
+}

--- a/src/main/java/com/hongik/devtalk/repository/seminar/LiveFileRepository.java
+++ b/src/main/java/com/hongik/devtalk/repository/seminar/LiveFileRepository.java
@@ -1,7 +1,11 @@
 package com.hongik.devtalk.repository.seminar;
 
 import com.hongik.devtalk.domain.LiveFile;
+import com.hongik.devtalk.domain.Seminar;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LiveFileRepository extends JpaRepository<LiveFile, Long> {
+    List<LiveFile> findBySeminar(Seminar seminar);
 }

--- a/src/main/java/com/hongik/devtalk/repository/seminar/SeminarRepository.java
+++ b/src/main/java/com/hongik/devtalk/repository/seminar/SeminarRepository.java
@@ -17,4 +17,8 @@ public interface SeminarRepository extends JpaRepository<Seminar,Long> {
     Seminar findSeminarInApplicationPeriod(@Param("now") LocalDateTime now);
 
     List<Seminar> findAllByOrderBySeminarNumDesc();
+
+    boolean existsBySeminarNum(Integer seminarNum);
+
+    boolean existsBySeminarNumAndIdNot(Integer seminarNum, Long id);
 }

--- a/src/main/java/com/hongik/devtalk/repository/speaker/SpeakerRepository.java
+++ b/src/main/java/com/hongik/devtalk/repository/speaker/SpeakerRepository.java
@@ -1,0 +1,7 @@
+package com.hongik.devtalk.repository.speaker;
+
+import com.hongik.devtalk.domain.Speaker;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpeakerRepository extends JpaRepository<Speaker, Long> {
+}

--- a/src/main/java/com/hongik/devtalk/service/seminar/SeminarAdminCommandService.java
+++ b/src/main/java/com/hongik/devtalk/service/seminar/SeminarAdminCommandService.java
@@ -1,18 +1,35 @@
 package com.hongik.devtalk.service.seminar;
 
-import com.hongik.devtalk.domain.Review;
+import com.hongik.devtalk.domain.*;
+import com.hongik.devtalk.domain.enums.SeminarStatus;
+import com.hongik.devtalk.domain.seminar.admin.dto.SeminarRegisterRequestDTO;
+import com.hongik.devtalk.domain.seminar.admin.dto.SeminarInfoResponseDTO;
 import com.hongik.devtalk.global.apiPayload.code.GeneralErrorCode;
 import com.hongik.devtalk.global.apiPayload.exception.GeneralException;
+import com.hongik.devtalk.repository.SessionRepository;
 import com.hongik.devtalk.repository.review.ReviewRepository;
+import com.hongik.devtalk.repository.seminar.LiveFileRepository;
+import com.hongik.devtalk.repository.seminar.SeminarRepository;
+import com.hongik.devtalk.repository.speaker.SpeakerRepository;
+import com.hongik.devtalk.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class SeminarAdminCommandService {
 
     private final ReviewRepository reviewRepository;
+    private final SeminarRepository seminarRepository;
+    private final SpeakerRepository speakerRepository;
+    private final SessionRepository sessionRepository;
+    private final LiveFileRepository liveFileRepository;
+    private final S3Service s3Service;
 
     /**
      * 후기 ID로 특정 후기를 홈 화면에 노출
@@ -57,5 +74,180 @@ public class SeminarAdminCommandService {
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
 
         reviewRepository.delete(review);
+    }
+
+    /**
+     * 세미나 등록
+     *
+     * @param request 세미나 등록 요청 DTO
+     * @param thumbnailFile 세미나 대표 썸네일
+     * @param materials 세미나 자료 파일 리스트
+     * @param speakerProfiles 연사 프로필 이미지 리스트
+     * @return 등록된 세미나 정보 DTO
+     * @throws GeneralException 기간 검증, 파일 검증 실패 시
+     */
+    @Transactional
+    public SeminarInfoResponseDTO registerSeminar(
+            SeminarRegisterRequestDTO request,
+            MultipartFile thumbnailFile,
+            List<MultipartFile> materials,
+            List<MultipartFile> speakerProfiles
+    ) {
+        validatePeriods(request);
+        validateSpeakersAndProfiles(request, speakerProfiles);
+
+        // 세미나 정보
+        // 이미지 타입 확인
+        if (!s3Service.isValidImageFile(thumbnailFile)) {
+            throw new GeneralException(GeneralErrorCode.UNSUPPORTED_FILE_TYPE);
+        }
+
+        // S3 업로드
+        String thumbnailUrl = s3Service.uploadFile(thumbnailFile, "seminar/thumbnail");
+
+        // 세미나 저장
+        Seminar seminar = Seminar.builder()
+                .seminarNum(request.getSeminarNum())
+                .topic(request.getTopic())
+                .seminarDate(request.getSeminarDate())
+                .place(request.getPlace())
+                .activeStartDate(request.getActiveStartDate())
+                .activeEndDate(request.getActiveEndDate())
+                .startDate(request.getApplyStartDate())
+                .endDate(request.getApplyEndDate())
+                .status(SeminarStatus.UPCOMING)
+                .thumbnailUrl(thumbnailUrl)
+                .thumbnailFileName(getFileName(thumbnailFile.getOriginalFilename()))
+                .thumbnailFileExtension(getExtension(thumbnailFile.getOriginalFilename()))
+                .thumbnailFileSize(thumbnailFile.getSize())
+                .build();
+        seminarRepository.save(seminar);
+
+        // 세미나 자료
+        List<SeminarInfoResponseDTO.FileInfo> materialInfos = new ArrayList<>();
+        if (materials != null) {
+            for (MultipartFile file : materials) {
+                // S3 업로드
+                String url = s3Service.uploadFile(file, "seminar/material");
+                // 세미나 자료 저장
+                LiveFile livefile = LiveFile.builder()
+                        .seminar(seminar)
+                        .fileUrl(url)
+                        .fileName(getFileName(file.getOriginalFilename()))
+                        .fileExtension(getExtension(file.getOriginalFilename()))
+                        .fileSize(file.getSize())
+                        .build();
+                liveFileRepository.save(livefile);
+
+                materialInfos.add(toFileInfo(file, url));
+            }
+        }
+
+        // 연사 + 세션 정보
+        // 이미지 타입 확인
+        for (MultipartFile profile : speakerProfiles) {
+            if (!s3Service.isValidImageFile(profile)) {
+                throw new GeneralException(GeneralErrorCode.UNSUPPORTED_FILE_TYPE);
+            }
+        }
+
+        List<SeminarInfoResponseDTO.SpeakerResponse> speakerInfos = new ArrayList<>();
+        for (int i = 0; i < request.getSpeakers().size(); i++) {
+            SeminarRegisterRequestDTO.SpeakerRegisterRequest sp = request.getSpeakers().get(i);
+            MultipartFile profile = speakerProfiles.get(i);
+
+            // S3 업로드
+            String profileUrl = s3Service.uploadFile(profile, "seminar/speaker");
+
+            // 연사 + 세션 저장
+            Speaker speaker = Speaker.builder()
+                    .name(sp.getName())
+                    .organization(sp.getOrganization())
+                    .history(sp.getHistory())
+                    .profileUrl(profileUrl)
+                    .profileFileName(getFileName(profile.getOriginalFilename()))
+                    .profileFileExtension(getExtension(profile.getOriginalFilename()))
+                    .profileFileSize(profile.getSize())
+                    .build();
+            speakerRepository.save(speaker);
+
+            Session session = Session.builder()
+                    .seminar(seminar)
+                    .speaker(speaker)
+                    .title(sp.getSessionTitle())
+                    .description(sp.getSessionContent())
+                    .build();
+            sessionRepository.save(session);
+
+            speakerInfos.add(
+                    SeminarInfoResponseDTO.SpeakerResponse.builder()
+                            .speakerId(speaker.getId())
+                            .name(speaker.getName())
+                            .organization(speaker.getOrganization())
+                            .history(speaker.getHistory())
+                            .sessionTitle(sp.getSessionTitle())
+                            .sessionContent(sp.getSessionContent())
+                            .profile(toFileInfo(profile, profileUrl))
+                            .build()
+            );
+        }
+
+        return SeminarInfoResponseDTO.builder()
+                .seminarId(seminar.getId())
+                .seminarNum(seminar.getSeminarNum())
+                .topic(seminar.getTopic())
+                .seminarDate(seminar.getSeminarDate())
+                .place(seminar.getPlace())
+                .liveLink(request.getLiveLink())
+                .activeStartDate(seminar.getActiveStartDate())
+                .activeEndDate(request.getActiveEndDate())
+                .applyStartDate(request.getApplyStartDate())
+                .applyEndDate(request.getApplyEndDate())
+                .thumbnail(toFileInfo(thumbnailFile, thumbnailUrl))
+                .materials(materialInfos)
+                .speakers(speakerInfos)
+                .build();
+    }
+
+    // 세미나 기간 검증
+    private void validatePeriods(SeminarRegisterRequestDTO req) {
+        if (!req.getActiveStartDate().isBefore(req.getActiveEndDate())
+                || !req.getApplyStartDate().isBefore(req.getApplyEndDate())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PERIOD_ORDER);
+        }
+
+        if (req.getApplyStartDate().isBefore(req.getActiveStartDate())
+                || req.getApplyEndDate().isAfter(req.getActiveEndDate())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_SEMINAR_PERIOD);
+        }
+    }
+
+    // 연사 수와 프로필 이미지 수가 일치하는지 검증
+    private void validateSpeakersAndProfiles(SeminarRegisterRequestDTO req, List<MultipartFile> speakerProfiles) {
+        if (req.getSpeakers().size() != speakerProfiles.size()) {
+            throw new GeneralException(GeneralErrorCode.INVALID_SPEAKER_PROFILE_COUNT);
+        }
+    }
+
+    // 파일 확장자 추출
+    private String getExtension(String fileName) {
+        if (fileName == null || !fileName.contains(".")) return null;
+        return fileName.substring(fileName.lastIndexOf('.') + 1);
+    }
+
+    // 파일 확장자를 제외한 이름만 추출
+    private String getFileName(String fileName) {
+        if (fileName == null) return null;
+        int dotIndex = fileName.lastIndexOf('.');
+        return (dotIndex == -1) ? fileName : fileName.substring(0, dotIndex);
+    }
+
+    private SeminarInfoResponseDTO.FileInfo toFileInfo(MultipartFile file, String url) {
+        return SeminarInfoResponseDTO.FileInfo.builder()
+                .fileName(getFileName(file.getOriginalFilename()))
+                .fileExtension(getExtension(file.getOriginalFilename()))
+                .fileSize(file.getSize())
+                .fileUrl(url)
+                .build();
     }
 }

--- a/src/main/java/com/hongik/devtalk/service/seminar/SeminarAdminCommandService.java
+++ b/src/main/java/com/hongik/devtalk/service/seminar/SeminarAdminCommandService.java
@@ -81,7 +81,6 @@ public class SeminarAdminCommandService {
                 .activeEndDate(request.getActiveEndDate())
                 .startDate(request.getApplyStartDate())
                 .endDate(request.getApplyEndDate())
-                .status(SeminarStatus.UPCOMING)
                 .thumbnailUrl(thumbnailUrl)
                 .thumbnailFileName(getFileName(thumbnailFile.getOriginalFilename()))
                 .thumbnailFileExtension(getExtension(thumbnailFile.getOriginalFilename()))

--- a/src/main/java/com/hongik/devtalk/service/seminar/SeminarAdminCommandService.java
+++ b/src/main/java/com/hongik/devtalk/service/seminar/SeminarAdminCommandService.java
@@ -10,7 +10,6 @@ import com.hongik.devtalk.global.apiPayload.exception.GeneralException;
 import com.hongik.devtalk.repository.SessionRepository;
 import com.hongik.devtalk.repository.live.LiveRepository;
 import com.hongik.devtalk.repository.liveFile.LiveFileRepository;
-import com.hongik.devtalk.repository.review.ReviewRepository;
 import com.hongik.devtalk.repository.seminar.SeminarRepository;
 import com.hongik.devtalk.repository.speaker.SpeakerRepository;
 import com.hongik.devtalk.service.S3Service;
@@ -27,58 +26,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SeminarAdminCommandService {
 
-    private final ReviewRepository reviewRepository;
     private final SeminarRepository seminarRepository;
     private final SpeakerRepository speakerRepository;
     private final SessionRepository sessionRepository;
     private final LiveFileRepository liveFileRepository;
     private final LiveRepository liveRepository;
     private final S3Service s3Service;
-
-    /**
-     * 후기 ID로 특정 후기를 홈 화면에 노출
-     *
-     * @param reviewId 후기 ID
-     * @throws GeneralException 후기가 존재하지 않을 경우
-     */
-    @Transactional
-    public void exposeReviewToHome(Long reviewId) {
-        // 후기 존재 여부 확인
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
-
-        review.updateIsNote(true);
-    }
-
-    /**
-     * 후기 ID로 특정 후기를 홈 화면에서 숨김
-     *
-     * @param reviewId 후기 ID
-     * @throws GeneralException 후기가 존재하지 않을 경우
-     */
-    @Transactional
-    public void hideReviewFromHome(Long reviewId) {
-        // 후기 존재 여부 확인
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
-
-        review.updateIsNote(false);
-    }
-
-    /**
-     * 후기 ID로 특정 후기를 영구 삭제
-     *
-     * @param reviewId 후기 ID
-     * @throws GeneralException 후기가 존재하지 않을 경우
-     */
-    @Transactional
-    public void deleteReview(Long reviewId) {
-        // 후기 존재 여부 확인
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
-
-        reviewRepository.delete(review);
-    }
 
     /**
      * 세미나 등록
@@ -110,7 +63,7 @@ public class SeminarAdminCommandService {
         validateSpeakersAndProfiles(request.getSpeakers().size(), speakerProfiles);
 
         // 세미나 정보
-        // 이미지 타입 확인
+        // 썸네일 이미지 타입 검증
         if (!s3Service.isValidImageFile(thumbnailFile)) {
             throw new GeneralException(GeneralErrorCode.UNSUPPORTED_FILE_TYPE);
         }
@@ -172,6 +125,7 @@ public class SeminarAdminCommandService {
             SeminarRegisterRequestDTO.SpeakerRegisterRequest sp = request.getSpeakers().get(i);
             MultipartFile profile = speakerProfiles.get(i);
 
+            // 연사 프로필 이미지 타입 검증
             if (!s3Service.isValidImageFile(profile)) {
                 throw new GeneralException(GeneralErrorCode.UNSUPPORTED_FILE_TYPE);
             }
@@ -373,6 +327,7 @@ public class SeminarAdminCommandService {
             }
         }
 
+        // 응답 DTO 생성
         Live live = liveRepository.findBySeminar(seminar).orElse(null);
         List<LiveFile> liveFiles = liveFileRepository.findBySeminar(seminar);
         List<Session> sessions = sessionRepository.findSessionsBySeminar(seminar);

--- a/src/main/java/com/hongik/devtalk/service/seminar/SeminarReviewService.java
+++ b/src/main/java/com/hongik/devtalk/service/seminar/SeminarReviewService.java
@@ -1,0 +1,61 @@
+package com.hongik.devtalk.service.seminar;
+
+import com.hongik.devtalk.domain.Review;
+import com.hongik.devtalk.global.apiPayload.code.GeneralErrorCode;
+import com.hongik.devtalk.global.apiPayload.exception.GeneralException;
+import com.hongik.devtalk.repository.review.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SeminarReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    /**
+     * 후기 ID로 특정 후기를 홈 화면에 노출
+     *
+     * @param reviewId 후기 ID
+     * @throws GeneralException 후기가 존재하지 않을 경우
+     */
+    @Transactional
+    public void exposeReviewToHome(Long reviewId) {
+        // 후기 존재 여부 확인
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
+
+        review.updateIsNote(true);
+    }
+
+    /**
+     * 후기 ID로 특정 후기를 홈 화면에서 숨김
+     *
+     * @param reviewId 후기 ID
+     * @throws GeneralException 후기가 존재하지 않을 경우
+     */
+    @Transactional
+    public void hideReviewFromHome(Long reviewId) {
+        // 후기 존재 여부 확인
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
+
+        review.updateIsNote(false);
+    }
+
+    /**
+     * 후기 ID로 특정 후기를 영구 삭제
+     *
+     * @param reviewId 후기 ID
+     * @throws GeneralException 후기가 존재하지 않을 경우
+     */
+    @Transactional
+    public void deleteReview(Long reviewId) {
+        // 후기 존재 여부 확인
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
+
+        reviewRepository.delete(review);
+    }
+}


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용
1. 세미나 등록 API
    - 세미나 기본 정보 등록 (회차, 주제, 일시, 장소, 신청 기간, 활성화 기간, 라이브 링크)
    - 세미나 자료 파일 업로드 및 저장
    - 연사 정보 및 세션 등록 (연사 프로필 이미지 업로드 포함)
    - Seminar, Speaker, LiveFile 엔티티에 파일명, 확장자, 사이즈 필드 추가
    - 파일 업로드 시 관련 정보 저장 

2. 세미나 정보 수정 API
    - 세미나 기본 정보 수정 (회차, 주제, 일시, 장소, 신청 기간, 활성화 기간, 라이브 링크)

3. 세미나 파일 수정 API
    - 세미나 자료 파일 추가 및 삭제
    - 세미나 썸네일 교체 (기존 파일은 삭제)
    - 세미나 연사 프로필 사진 교체 (기존 파일은 삭제)

4. 세미나 영구 삭제 API
    - 세미나, 세션, 연사, 해당 세미나 신청자, 해당 세미나 후기 정보 삭제
    - 소프트딜리트 처리하면 다른 연관된 세미나 & 후기 관련 api들도 수정이 필요해서 우선은 하드딜리트 처리했습니다. 나중에 소프트 딜리트도 고려해봐야 할 것 같아요..!

## 📸 작업 화면 스크린샷
<img width="1089" height="561" alt="image" src="https://github.com/user-attachments/assets/07ab5bf2-1968-405b-b2d1-ad99e717e777" />
<img width="1057" height="347" alt="image" src="https://github.com/user-attachments/assets/e82297a7-004b-4f5e-bcfa-b647ddb35ac5" />
<img width="609" height="319" alt="image" src="https://github.com/user-attachments/assets/baf40f87-a794-4557-a68d-0945cb5b7847" />


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
