### PR TITLE
[Fix] 세미나 관리 에러 처리 수정 및 세미나 카드리스트 조회에 seminarId 추가

### DIFF
--- a/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
+++ b/src/main/java/com/hongik/devtalk/controller/seminar/SeminarAdminController.java
@@ -1,7 +1,6 @@
 package com.hongik.devtalk.controller.seminar;
 
 import com.hongik.devtalk.domain.seminar.admin.dto.*;
-import com.hongik.devtalk.domain.seminar.dto.SeminarListDto;
 import com.hongik.devtalk.global.apiPayload.ApiResponse;
 import com.hongik.devtalk.service.seminar.SeminarAdminCommandService;
 import com.hongik.devtalk.service.seminar.SeminarAdminQueryService;
@@ -30,7 +29,6 @@ public class SeminarAdminController {
     private final SeminarAdminQueryService seminarAdminQueryService;
     private final SeminarAdminCommandService seminarAdminCommandService;
     private final SeminarReviewService seminarReviewService;
-    private final SeminarListService seminarListService;
 
     @Operation(summary = "세미나 카드리스트 조회", description = "세미나 카드리스트를 조회합니다.")
     @ApiResponses({
@@ -39,8 +37,8 @@ public class SeminarAdminController {
                     content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @GetMapping("/card")
-    public ApiResponse<SeminarListDto.SeminarResDtoList> getSeminarCards() {
-        SeminarListDto.SeminarResDtoList result = seminarListService.seminarList();
+    public ApiResponse<SeminarCardResponseDTO.SeminarCardDTOList> getSeminarCards() {
+        SeminarCardResponseDTO.SeminarCardDTOList result = seminarAdminQueryService.getSeminarCardList();
         return ApiResponse.onSuccess("세미나 카드 리스트 조회에 성공했습니다.", result);
     }
 
@@ -213,6 +211,8 @@ public class SeminarAdminController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON2000", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REVIEW_4041", description = "후기 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REVIEW_4001", description = "비공개 후기는 홈 화면에 노출할 수 없음",
                     content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SERVER_5001", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ApiResponse.class)))

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarCardResponseDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarCardResponseDTO.java
@@ -1,0 +1,34 @@
+package com.hongik.devtalk.domain.seminar.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class SeminarCardResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SeminarCardDTOList {
+        private List<SeminarCardDTO> seminarList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SeminarCardDTO {
+
+        private Long seminarId;
+        private int seminarNum;
+        private String seminarTopic;
+        private LocalDateTime seminarDate;
+        private String place;
+        private String imageUrl;
+    }
+}

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarRegisterRequestDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarRegisterRequestDTO.java
@@ -24,7 +24,6 @@ public class SeminarRegisterRequestDTO {
     private Integer seminarNum;
 
     @NotNull
-    @FutureOrPresent(message = "세미나 날짜는 현재 시각 이후여야 합니다.")
     @Schema(description = "세미나 일시", example = "2025-12-10T10:00:00")
     private LocalDateTime seminarDate;
 
@@ -37,22 +36,18 @@ public class SeminarRegisterRequestDTO {
     private String topic;
 
     @NotNull
-    @FutureOrPresent(message = "세미나 활성화 시작일은 현재 시각 이후여야 합니다.")
     @Schema(description = "세미나 활성화 시작일", example = "2025-12-01T00:00:00")
     private LocalDateTime activeStartDate;
 
     @NotNull
-    @FutureOrPresent(message = "세미나 활성화 종료일은 현재 시각 이후여야 합니다.")
     @Schema(description = "세미나 활성화 종료일", example = "2025-12-15T23:59:59")
     private LocalDateTime activeEndDate;
 
     @NotNull
-    @FutureOrPresent(message = "세미나 신청 시작일은 현재 시각 이후여야 합니다.")
     @Schema(description = "세미나 신청 시작일", example = "2025-12-01T09:00:00")
     private LocalDateTime applyStartDate;
 
     @NotNull
-    @FutureOrPresent(message = "세미나 신청 종료일은 현재 시각 이후여야 합니다.")
     @Schema(description = "세미나 신청 종료일", example = "2025-12-05T18:00:00")
     private LocalDateTime applyEndDate;
 

--- a/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarUpdateRequestDTO.java
+++ b/src/main/java/com/hongik/devtalk/domain/seminar/admin/dto/SeminarUpdateRequestDTO.java
@@ -24,7 +24,6 @@ public class SeminarUpdateRequestDTO {
     private Integer seminarNum;
 
     @NotNull
-    @FutureOrPresent
     @Schema(description = "세미나 일시", example = "2025-12-10T10:00:00")
     private LocalDateTime seminarDate;
 
@@ -37,22 +36,18 @@ public class SeminarUpdateRequestDTO {
     private String topic;
 
     @NotNull
-    @FutureOrPresent
     @Schema(description = "세미나 활성화 시작일", example = "2025-12-01T00:00:00")
     private LocalDateTime activeStartDate;
 
     @NotNull
-    @FutureOrPresent
     @Schema(description = "세미나 활성화 종료일", example = "2025-12-15T23:59:59")
     private LocalDateTime activeEndDate;
 
     @NotNull
-    @FutureOrPresent
     @Schema(description = "세미나 신청 시작일", example = "2025-12-01T09:00:00")
     private LocalDateTime applyStartDate;
 
     @NotNull
-    @FutureOrPresent
     @Schema(description = "세미나 신청 종료일", example = "2025-12-05T18:00:00")
     private LocalDateTime applyEndDate;
 

--- a/src/main/java/com/hongik/devtalk/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/hongik/devtalk/global/apiPayload/code/GeneralErrorCode.java
@@ -41,6 +41,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
 
     // 후기 에러
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_4041", "존재하지 않는 후기입니다."),
+    REVIEW_NOT_PUBLIC(HttpStatus.BAD_REQUEST, "REVIEW_4001", "비공개 후기는 홈 화면에 노출할 수 없습니다."),
     INCOMPLETE_REVIEW_ORDER(HttpStatus.BAD_REQUEST, "REVIEW_4002", "화면에 표시되어야 하는 후기 중 누락된 업데이트가 존재합니다."),
 
     // 요청/파라미터 에러

--- a/src/main/java/com/hongik/devtalk/service/seminar/SeminarAdminQueryService.java
+++ b/src/main/java/com/hongik/devtalk/service/seminar/SeminarAdminQueryService.java
@@ -1,10 +1,7 @@
 package com.hongik.devtalk.service.seminar;
 
 import com.hongik.devtalk.domain.*;
-import com.hongik.devtalk.domain.seminar.admin.dto.ApplicantResponseDTO;
-import com.hongik.devtalk.domain.seminar.admin.dto.QuestionResponseDTO;
-import com.hongik.devtalk.domain.seminar.admin.dto.SeminarInfoResponseDTO;
-import com.hongik.devtalk.domain.seminar.admin.dto.SeminarNumResponseDTO;
+import com.hongik.devtalk.domain.seminar.admin.dto.*;
 import com.hongik.devtalk.global.apiPayload.code.GeneralErrorCode;
 import com.hongik.devtalk.global.apiPayload.exception.GeneralException;
 import com.hongik.devtalk.repository.ApplicantRepository;
@@ -123,6 +120,31 @@ public class SeminarAdminQueryService {
         List<Integer> seminarNums = seminarRepository.findAllSeminarNums();
         return SeminarNumResponseDTO.builder()
                 .seminarNums(seminarNums)
+                .build();
+    }
+
+    /**
+     * 세미나 카드 리스트 조회
+     *
+     * @return 세미나 카드 리스트 DTO
+     */
+    public SeminarCardResponseDTO.SeminarCardDTOList getSeminarCardList() {
+
+        List<SeminarCardResponseDTO.SeminarCardDTO> seminarCards =
+                seminarRepository.findAllByOrderBySeminarNumDesc()
+                        .stream()
+                        .map(s -> SeminarCardResponseDTO.SeminarCardDTO.builder()
+                                .seminarId(s.getId())
+                                .seminarNum(s.getSeminarNum())
+                                .seminarTopic(s.getTopic())
+                                .seminarDate(s.getSeminarDate())
+                                .place(s.getPlace())
+                                .imageUrl(s.getThumbnailUrl())
+                                .build())
+                        .toList();
+
+        return SeminarCardResponseDTO.SeminarCardDTOList.builder()
+                .seminarList(seminarCards)
                 .build();
     }
 }

--- a/src/main/java/com/hongik/devtalk/service/seminar/SeminarReviewService.java
+++ b/src/main/java/com/hongik/devtalk/service/seminar/SeminarReviewService.java
@@ -21,13 +21,18 @@ public class SeminarReviewService {
      * 후기 ID로 특정 후기를 홈 화면에 노출
      *
      * @param reviewId 후기 ID
-     * @throws GeneralException 후기가 존재하지 않을 경우
+     * @throws GeneralException 후기가 존재하지 않거나 비공개일 경우
      */
     @Transactional
     public void exposeReviewToHome(Long reviewId) {
         // 후기 존재 여부 확인
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
+
+        // 비공개 후기일 경우 에러
+        if (!review.isPublic()) {
+            throw new GeneralException(GeneralErrorCode.REVIEW_NOT_PUBLIC);
+        }
 
         review.updateIsNote(true);
     }


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [x] 코드 수정
- [ ] 배포
- [ ] 기타

## 📋 세부 내용
- 기존에 유저 - 세미나 리스트 조회와 어드민 - 세미나 카드 리스트 조회가 같은 서비스를 사용했었는데 어드민쪽에 seminarId 필드가 추가로 필요하여 서비스 분리했습니다.
- 비공개인 후기는 홈화면에 추가할 시 에러가 뜨도록 처리했습니다.
- 과거 세미나를 등록하거나 수정하는 경우가 생길 것 같아서 세미나 관련 날짜가 미래여야 한다는 조건을 삭제했습니다.

## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?
