### PR TITLE
[Feat] 후기 홈화면 노출 시 displayOrder 값 설정

### DIFF
--- a/src/main/java/com/hongik/devtalk/repository/review/ReviewRepository.java
+++ b/src/main/java/com/hongik/devtalk/repository/review/ReviewRepository.java
@@ -22,4 +22,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "left join fetch s.departments " +
             "where r.seminar.id = :seminarId")
     List<Review> findBySeminarIdWithStudentAndDepartments(@Param("seminarId") Long seminarId);
+
+    // 공개 + 홈화면에 노출된 리뷰 중 displayOrder의 최댓값 반환
+    @Query("SELECT MAX(r.displayOrder) FROM Review r WHERE r.isPublic = true AND r.isNote = true")
+    Integer findMaxDisplayOrder();
 }

--- a/src/main/java/com/hongik/devtalk/service/seminar/SeminarReviewService.java
+++ b/src/main/java/com/hongik/devtalk/service/seminar/SeminarReviewService.java
@@ -34,7 +34,12 @@ public class SeminarReviewService {
             throw new GeneralException(GeneralErrorCode.REVIEW_NOT_PUBLIC);
         }
 
+        // 다음 순서값 - 현재 노출 중인 후기 중 displayOrder 최댓값 + 1
+        Integer maxDisplayOrder = reviewRepository.findMaxDisplayOrder();
+        int nextDisplayOrder = (maxDisplayOrder == null) ? 1 : maxDisplayOrder + 1;
+
         review.updateIsNote(true);
+        review.updateDisplayOrder(nextDisplayOrder);
     }
 
     /**
@@ -50,6 +55,7 @@ public class SeminarReviewService {
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.REVIEW_NOT_FOUND));
 
         review.updateIsNote(false);
+        review.updateDisplayOrder(null);
     }
 
     /**


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
세미나 상세 조회 페이지에서 후기를 홈 화면에 노출할 경우, 현재 공개(isPublic = true) 상태이며 홈 화면에 노출(isNote = true) 중인 후기들의 displayOrder 최댓값에 +1을 더해 새로운 순서값으로 설정합니다.
반대로 후기를 홈 화면에서 숨길 경우, 해당 후기의 displayOrder 값을 null로 초기화합니다.

## ⚠️ PR하기 전에 확인해주세요
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?